### PR TITLE
:sparkles: Feat: JWT 토큰 재발급

### DIFF
--- a/account/urls.py
+++ b/account/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('signup/', views.signup, name='signup'),
     path('login/', views.login, name='login'),
+    path('refresh/', views.refresh, name='refresh')
 ]

--- a/account/views.py
+++ b/account/views.py
@@ -1,6 +1,7 @@
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.generics import CreateAPIView
-from rest_framework_simplejwt.views import TokenObtainPairView
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from .serializers import SignupSerializer, LoginSerializer
 class SignupView(CreateAPIView):
@@ -25,7 +26,16 @@ class LoginView(TokenObtainPairView):
             'refresh': str(refresh),
             'access': str(access),
         })
+    
+
+class RefreshView(TokenRefreshView):
+    '''
+    토큰 갱신 API
+    '''
+    def post(self, request: Request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
 
 
 signup = SignupView.as_view()
 login = LoginView.as_view()
+refresh = RefreshView.as_view()


### PR DESCRIPTION
- 수정 파일
.\account 하위 tests.py, urls.py, views.py

- 개발 사항
만료된 access_token을 refresh_token으로 재발급받는 기능 개발

- 테스트 사항
정상 토큰 재발급 테스트
만료된 토큰 재발급 테스트

- 테스트 코드
`python manage.py test account.tests.TestAccount.test_token_refresh`