### PR TITLE
:sparkles: Feat: 렌트카 삭제 API

### DIFF
--- a/pick/tests.py
+++ b/pick/tests.py
@@ -811,3 +811,83 @@ class TestPickRentalCar(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
         print('-- 렌트카 찜 리스트 조회 테스트 END --')
+
+    def test_pick_rental_car_delete(self):
+        '''
+        렌트카 찜 삭제 테스트
+        1. 미로그인 상태에서 렌트카 찜 삭제 요청 테스트
+        2. 존재하지 않는 렌트카 찜 삭제 요청 테스트
+        3. 다른 사용자의 렌트카 찜 삭제 요청 테스트
+        4. 로그인 상태에서 본인 렌트카 찜 삭제 요청 테스트
+        '''
+        print('-- 렌트카 찜 삭제 테스트 BEGIN --')
+        data = {
+            'user':1,
+            'pick_type': 'RC',
+        }
+        for i in range(1, 6):
+            self.client.post(
+                '/pick/rental_car/',
+                data={
+                    'rental_car': i,
+                    'pick_type': 'RC',
+                    'user': 1,},
+                HTTP_AUTHORIZATION=f'Bearer {self.access_token}',
+                format='json')
+            
+        # 미로그인 상태에서 렌트카 찜 삭제 요청
+        response = self.client.delete(
+            '/pick/rental_car/1/',
+            data=data,
+            format='json')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data['detail'], '로그인이 필요합니다.')
+
+        # 존재하지 않는 렌트카 찜 삭제 요청
+        response = self.client.delete(
+            '/pick/rental_car/10/',
+            HTTP_AUTHORIZATION=f'Bearer {self.access_token}',
+            data=data,
+            format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['message'], '해당 렌트카를 찜한 기록이 없습니다.')
+
+        # 다른 사용자의 렌트카 찜 삭제 요청
+        # 사용자 생성 & 로그인
+        data = {
+            'email': 'test1@gmail.com',
+            'username': 'test',
+            'nickname': 'test1',
+            'password': 'testtest1@',
+            'password2': 'testtest1@',
+        }
+        self.client.post(
+            '/account/signup/', 
+            data,
+            format='json')
+        data = {
+            'email': 'test1@gmail.com',
+            'password': 'testtest1@',
+        }
+        response = self.client.post(
+            '/account/login/',
+            data,
+            format='json')
+        access = response.data['access']
+        response = self.client.delete(
+            '/pick/rental_car/1/',
+            HTTP_AUTHORIZATION=f'Bearer {access}',
+            data=data,
+            format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['message'], '해당 렌트카를 찜한 기록이 없습니다.')
+
+        # 로그인 상태에서 본인 렌트카 찜 삭제 요청
+        response = self.client.delete(
+            '/pick/rental_car/1/',
+            HTTP_AUTHORIZATION=f'Bearer {self.access_token}',
+            data=data,
+            format='json')
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(Pick.objects.all().count(), 4)
+        print('-- 렌트카 찜 삭제 테스트 END --')

--- a/pick/urls.py
+++ b/pick/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('train/', views.train_pick, name='train_pick_cl'),
     path('train/<int:pk>/', views.train_pick, name='train_pick_d'),
     path('rental_car/', views.rental_car_pick, name='rental_car_pick_cl'),
+    path('rental_car/<int:pk>/', views.rental_car_pick, name='rental_car_pick_d'),
 ]

--- a/pick/views.py
+++ b/pick/views.py
@@ -167,6 +167,18 @@ class RentalCarPickViewSet(ModelViewSet):
         queryset = super().get_queryset()
         queryset = queryset.filter(user=self.request.user)
         return queryset
+    
+    def get_object(self):
+        obj = Pick.objects.all().filter(user=self.request.user, rental_car=self.kwargs['pk'])
+        if not obj:
+            raise ObjectDoesNotExist()
+        return obj
+    
+    def destroy(self, request, *args, **kwargs):
+        try:
+            return super().destroy(request, *args, **kwargs)
+        except ObjectDoesNotExist:
+            return Response({'message': '해당 렌트카를 찜한 기록이 없습니다.'}, status=status.HTTP_400_BAD_REQUEST)
 
 lodging_pick = LodgingPickViewSet.as_view({
     'post': 'create',


### PR DESCRIPTION
- 개발 사항
	- 로그인한 사용자 대상 본인이 등록한 렌트카 찜 삭제 기능 개발

- 테스트 사항
	- 미로그인 상태에서 렌트카 찜 삭제 요청 테스트 - 존재하지 않는 렌트카 찜 삭제 요청 테스트 - 다른 사용자의 렌트카 찜 삭제 요청 테스트 - 로그인 상태에서 본인 렌트카 찜 삭제 요청 테스트

- 테스트 명령어
	- `python manage.py test pick.tests.TestPickRentalCar.test_pick_rental_car_delete`